### PR TITLE
Add terrain object spawner

### DIFF
--- a/Assets/Scripts/TerrainChunk.cs
+++ b/Assets/Scripts/TerrainChunk.cs
@@ -28,6 +28,10 @@ namespace EndlessWorld
             transform.position = new Vector3(coord.x*w, 0, coord.y*w);
             gameObject.name    = $"Chunk {coord.x},{coord.y}";
             GetComponent<MeshRenderer>().sharedMaterial = mat;
+
+            /* spawn objects if component present */
+            GetComponent<TerrainObjectSpawner>()?.Initialize(
+                size, spacing, noiseScale, heightMult, coord);
         }
 
         /* ------------------ helpers ------------------ */

--- a/Assets/Scripts/TerrainObjectSpawner.cs
+++ b/Assets/Scripts/TerrainObjectSpawner.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+
+namespace EndlessWorld
+{
+    [System.Serializable]
+    public class SpawnRule
+    {
+        public GameObject prefab;
+        [Range(0f,1f)] public float minHeight = 0f;
+        [Range(0f,1f)] public float maxHeight = 1f;
+        [Range(0f,1f)] public float density = 0.1f;
+    }
+
+    /// <summary>
+    /// Spawns objects on terrain chunks based on height thresholds.
+    /// </summary>
+    public class TerrainObjectSpawner : MonoBehaviour
+    {
+        public SpawnRule[] rules;
+
+        int _size;
+        float _spacing;
+        float _noiseScale;
+        float _heightMult;
+        Vector2Int _coord;
+
+        static int _seed = 12345; // must match TerrainChunk
+
+        public void Initialize(int size, float spacing, float noiseScale,
+                               float heightMult, Vector2Int coord)
+        {
+            _size = size;
+            _spacing = spacing;
+            _noiseScale = noiseScale;
+            _heightMult = heightMult;
+            _coord = coord;
+
+            ClearObjects();
+            SpawnObjects();
+        }
+
+        void ClearObjects()
+        {
+            foreach (Transform child in transform)
+                Destroy(child.gameObject);
+        }
+
+        void SpawnObjects()
+        {
+            if (rules == null) return;
+
+            float world = (_size - 1) * _spacing;
+            foreach (var rule in rules)
+            {
+                if (!rule.prefab) continue;
+                int attempts = Mathf.RoundToInt(rule.density * _size * _size);
+                for (int i = 0; i < attempts; i++)
+                {
+                    float x = Random.Range(0f, world);
+                    float z = Random.Range(0f, world);
+                    float wx = _coord.x * world + x;
+                    float wz = _coord.y * world + z;
+                    float h01 = Mathf.PerlinNoise((wx + _seed) / _noiseScale,
+                                                  (wz + _seed) / _noiseScale);
+                    if (h01 < rule.minHeight || h01 > rule.maxHeight)
+                        continue;
+
+                    float h = h01 * _heightMult;
+                    Vector3 pos = new Vector3(x, h, z) + transform.position;
+                    Instantiate(rule.prefab, pos, Quaternion.identity, transform);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/TerrainObjectSpawner.cs.meta
+++ b/Assets/Scripts/TerrainObjectSpawner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8487c56d5958494b98700e5527b4be4a


### PR DESCRIPTION
## Summary
- allow terrain chunks to spawn objects after construction
- add `TerrainObjectSpawner` component that instantiates prefabs based on height ranges

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68822bea03bc8321b8f2d2d7983ec459