### PR TITLE
Add basic tree spawning

### DIFF
--- a/Assets/New World Settings.asset
+++ b/Assets/New World Settings.asset
@@ -22,3 +22,7 @@ MonoBehaviour:
   sandHeight: 0.35
   stoneHeight: 0.75
   textureTiling: 8
+  treePrefab: {fileID: 0}
+  treeMinHeight: 0.4
+  treeMaxHeight: 0.7
+  treeDensity: 0.1

--- a/Assets/Scripts/EndlessTerrain.cs
+++ b/Assets/Scripts/EndlessTerrain.cs
@@ -51,7 +51,9 @@ namespace EndlessWorld
                     world.noiseScale, world.heightMultiplier,
                     world.sandHeight, world.stoneHeight,
                     _sharedMat,
-                    c);
+                    c,
+                    world.treePrefab, world.treeMinHeight,
+                    world.treeMaxHeight, world.treeDensity);
                 _loaded.Add(c, tc);
             }
 

--- a/Assets/Scripts/TerrainChunkPool.cs
+++ b/Assets/Scripts/TerrainChunkPool.cs
@@ -10,7 +10,9 @@ namespace EndlessWorld
         public TerrainChunk Get(int size, float spacing, float noiseScale,
                                 float heightMult, float sandT, float stoneT,
                                 Material mat,
-                                Vector2Int coord)
+                                Vector2Int coord,
+                                GameObject treePrefab, float treeMinHeight,
+                                float treeMaxHeight, float treeDensity)
         {
             TerrainChunk tc = _pool.Count > 0
                               ? _pool.Pop()
@@ -18,7 +20,8 @@ namespace EndlessWorld
 
             tc.transform.parent = transform;
             tc.Build(size, spacing, noiseScale, heightMult,
-                     sandT, stoneT, mat, coord);
+                     sandT, stoneT, mat, coord,
+                     treePrefab, treeMinHeight, treeMaxHeight, treeDensity);
 
             tc.gameObject.SetActive(true);
             return tc;

--- a/Assets/Scripts/WorldSettings.cs
+++ b/Assets/Scripts/WorldSettings.cs
@@ -19,5 +19,11 @@ namespace EndlessWorld
         [Range(0f,1f)] public float stoneHeight = 0.75f;
         public float textureTiling = 8f;
 
+        [Header("Tree Settings")]
+        public GameObject treePrefab;
+        [Range(0f,1f)] public float treeMinHeight = 0.4f;
+        [Range(0f,1f)] public float treeMaxHeight = 0.7f;
+        [Range(0f,1f)] public float treeDensity = 0.1f;
+
     }
 }


### PR DESCRIPTION
## Summary
- extend world settings with tree prefab, spawn range and density
- spawn trees in terrain chunks according to terrain height
- pass tree parameters through pool and endless terrain
- update sample world settings asset with defaults

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883502e2c3083219d4cd5def77ba00d