### PR TITLE
Fix tree offsets in chunks

### DIFF
--- a/Assets/Scripts/TerrainChunk.cs
+++ b/Assets/Scripts/TerrainChunk.cs
@@ -26,14 +26,14 @@ namespace EndlessWorld
                                    noiseScale, heightMult,
                                    sandT, stoneT, coord);
 
-            SpawnTrees(size, spacing, noiseScale, heightMult, coord,
-                       treePrefab, treeMinHeight, treeMaxHeight, treeDensity);
-
             /* place & render */
             float w = (size - 1) * spacing;
             transform.position = new Vector3(coord.x * w, 0, coord.y * w);
             gameObject.name    = $"Chunk {coord.x},{coord.y}";
             GetComponent<MeshRenderer>().sharedMaterial = mat;
+
+            SpawnTrees(size, spacing, noiseScale, heightMult, coord,
+                       treePrefab, treeMinHeight, treeMaxHeight, treeDensity);
 
         }
 


### PR DESCRIPTION
## Summary
- prevent double offsets when spawning trees by setting chunk position before spawning them

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883553e7d0483219a15d0ae0dbdecc4