### PR TITLE
Integrate water into chunk object

### DIFF
--- a/Assets/Scripts/TerrainChunkPool.cs
+++ b/Assets/Scripts/TerrainChunkPool.cs
@@ -12,13 +12,14 @@ namespace EndlessWorld
                                 Material mat,
                                 Vector2Int coord,
                                 GameObject treePrefab, float treeMinHeight,
-                                float treeMaxHeight, float treeDensity)
+                                float treeMaxHeight, float treeDensity,
+                                Transform parent = null)
         {
             TerrainChunk tc = _pool.Count > 0
                               ? _pool.Pop()
                               : new GameObject("Chunk").AddComponent<TerrainChunk>();
 
-            tc.transform.parent = transform;
+            tc.transform.parent = parent ? parent : transform;
             tc.Build(size, spacing, noiseScale, heightMult,
                      sandT, stoneT, mat, coord,
                      treePrefab, treeMinHeight, treeMaxHeight, treeDensity);

--- a/Assets/Scripts/WaterChunkPool.cs
+++ b/Assets/Scripts/WaterChunkPool.cs
@@ -7,10 +7,10 @@ namespace EndlessWorld
     {
         readonly Stack<WaterChunk> _pool = new();
 
-        public WaterChunk Get(int size, float spacing, float height, Material mat, Vector2Int coord)
+        public WaterChunk Get(int size, float spacing, float height, Material mat, Vector2Int coord, Transform parent = null)
         {
             WaterChunk wc = _pool.Count > 0 ? _pool.Pop() : new GameObject("Water").AddComponent<WaterChunk>();
-            wc.transform.parent = transform;
+            wc.transform.parent = parent ? parent : transform;
             wc.Build(size, spacing, height, mat, coord);
             wc.gameObject.SetActive(true);
             return wc;


### PR DESCRIPTION
## Summary
- allow pools to set parent transforms
- add a `Chunk` data container
- spawn water as a child of each terrain chunk and release as a single unit

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68835826cfe0832182f6c128502ef9ee