### PR TITLE
Fix biome fallback logic

### DIFF
--- a/Assets/Scripts/EndlessTerrain.cs
+++ b/Assets/Scripts/EndlessTerrain.cs
@@ -120,7 +120,22 @@ namespace EndlessWorld
                 }
             }
 
-            return world.biomes[0];
+            // no biome fully matched, pick the closest one
+            Biome closest = world.biomes[0];
+            float bestDist2 = float.MaxValue;
+            foreach (var b in world.biomes)
+            {
+                float dh = heat < b.minHeat ? b.minHeat - heat : heat > b.maxHeat ? heat - b.maxHeat : 0f;
+                float dw = wet  < b.minWetness ? b.minWetness - wet : wet > b.maxWetness ? wet - b.maxWetness : 0f;
+                float d2 = dh*dh + dw*dw;
+                if (d2 < bestDist2)
+                {
+                    bestDist2 = d2;
+                    closest = b;
+                }
+            }
+
+            return closest;
         }
     }
 }


### PR DESCRIPTION
## Summary
- choose closest biome if no biome ranges matched
- fallback to closest biome for vertex coloring and tree placement

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_68836d0573d483218db1c372fb48d2ac