### PR TITLE
Fix biome texture tiling across chunks

### DIFF
--- a/Assets/Scripts/EndlessTerrain.cs
+++ b/Assets/Scripts/EndlessTerrain.cs
@@ -34,6 +34,8 @@ namespace EndlessWorld
                 var mat = new Material(Shader.Find("EndlessWorld/HeightBlend"));
                 if (b.texture) mat.SetTexture("_MainTex", b.texture);
                 mat.SetFloat("_Tiling", world.textureTiling);
+                float chunkWorldSize = (world.chunkSize - 1) * world.vertexSpacing;
+                mat.SetFloat("_ChunkSize", chunkWorldSize);
                 _biomeMats[b] = mat;
             }
 

--- a/Assets/Shaders/HeightBlend.shader
+++ b/Assets/Shaders/HeightBlend.shader
@@ -4,6 +4,7 @@ Shader "EndlessWorld/HeightBlend"
     {
         _MainTex("Texture", 2D) = "white" {}
         _Tiling("UV Tiling"    , Float) = 8
+        _ChunkSize("Chunk Size", Float) = 240
     }
     SubShader
     {
@@ -33,12 +34,14 @@ Shader "EndlessWorld/HeightBlend"
 
             TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
             float _Tiling;
+            float _ChunkSize;
 
             Varyings vert (Attributes IN)
             {
                 Varyings OUT;
-                OUT.positionHCS = TransformObjectToHClip(IN.positionOS);
-                OUT.uv = IN.uv * _Tiling;
+                float3 worldPos = TransformObjectToWorld(IN.positionOS);
+                OUT.positionHCS = TransformWorldToHClip(worldPos);
+                OUT.uv = (worldPos.xz / _ChunkSize) * _Tiling;
                 OUT.color = IN.color;
                 return OUT;
             }


### PR DESCRIPTION
## Summary
- add `_ChunkSize` parameter to **HeightBlend** shader and compute UVs in world space
- pass chunk world size to biome materials in `EndlessTerrain`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68836ef31f188321ae1cac4ee58859ec