### PR TITLE
Add base height for smoother biome transitions

### DIFF
--- a/Assets/ScriptableObjects/Biomes/New Biome 1.asset
+++ b/Assets/ScriptableObjects/Biomes/New Biome 1.asset
@@ -23,3 +23,4 @@ MonoBehaviour:
   treeDensity: 0.1
   noiseScale: 60
   heightMultiplier: 25
+  baseHeight: 0

--- a/Assets/ScriptableObjects/Biomes/New Biome.asset
+++ b/Assets/ScriptableObjects/Biomes/New Biome.asset
@@ -23,3 +23,4 @@ MonoBehaviour:
   treeDensity: 0.1
   noiseScale: 60
   heightMultiplier: 25
+  baseHeight: 0

--- a/Assets/Scripts/Biome.cs
+++ b/Assets/Scripts/Biome.cs
@@ -23,5 +23,6 @@ namespace EndlessWorld
         [Header("Terrain Settings")]
         public float noiseScale = 60f;
         public float heightMultiplier = 25f;
+        public float baseHeight = 0f;
     }
 }

--- a/Assets/Scripts/TerrainChunk.cs
+++ b/Assets/Scripts/TerrainChunk.cs
@@ -188,7 +188,7 @@ namespace EndlessWorld
 
                         float bh = Mathf.PerlinNoise((wx + _seed) / biome.noiseScale,
                                                      (wz + _seed) / biome.noiseScale) *
-                                   biome.heightMultiplier;
+                                   biome.heightMultiplier + biome.baseHeight;
                         hSum += bh * bw;
                         col  += biome.color * bw;
                         wSum += bw;
@@ -206,7 +206,7 @@ namespace EndlessWorld
                     Biome cb = ClosestBiome(heat, wet, biomes, out domIndex);
                     float bh = Mathf.PerlinNoise((wx + _seed) / cb.noiseScale,
                                                  (wz + _seed) / cb.noiseScale) *
-                               cb.heightMultiplier;
+                               cb.heightMultiplier + cb.baseHeight;
                     heights[i] = bh;
                     col        = cb.color;
                     col.a      = 1f;


### PR DESCRIPTION
## Summary
- add `baseHeight` setting to `Biome`
- include `baseHeight` when generating terrain heights
- update biome scriptable objects to use the new setting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688741f227d8832197a757e0c9ea2879