### PR TITLE
Implement procedural world generation

### DIFF
--- a/Assets/Scripts/World/Biomes/BiomeDefinition.cs
+++ b/Assets/Scripts/World/Biomes/BiomeDefinition.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "World/Biome")]
+public class BiomeDefinition : ScriptableObject
+{
+    public string biomeName = "New Biome";
+
+    [Range(0f,1f)]
+    public float minThreshold = 0f;
+    [Range(0f,1f)]
+    public float maxThreshold = 1f;
+
+    public float heightMultiplier = 5f;
+    public float roughness = 1f;
+    public AnimationCurve heightCurve = AnimationCurve.Linear(0,0,1,1);
+
+    public Texture2D texture;
+    public GameObject[] treePrefabs;
+    public GameObject[] mobPrefabs;
+}

--- a/Assets/Scripts/World/Chunks/TerrainChunk.cs
+++ b/Assets/Scripts/World/Chunks/TerrainChunk.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent(typeof(MeshFilter), typeof(MeshRenderer))]
+public class TerrainChunk : MonoBehaviour
+{
+    MeshFilter meshFilter;
+    MeshCollider meshCollider;
+
+    public Vector2Int Coord { get; private set; }
+    WorldGenerator generator;
+
+    readonly List<GameObject> spawnedObjects = new List<GameObject>();
+
+    public void Init(WorldGenerator generator, Vector2Int coord)
+    {
+        this.generator = generator;
+        Coord = coord;
+        name = $"Chunk_{coord.x}_{coord.y}";
+        meshFilter = GetComponent<MeshFilter>();
+        meshCollider = GetComponent<MeshCollider>();
+        Generate();
+    }
+
+    void Generate()
+    {
+        float size = generator.chunkSize;
+        int resolution = generator.chunkResolution;
+        float[,] heights = new float[resolution + 1, resolution + 1];
+        Vector3[] verts = new Vector3[(resolution + 1) * (resolution + 1)];
+        Vector2[] uvs = new Vector2[verts.Length];
+        int[] tris = new int[resolution * resolution * 6];
+
+        for (int z = 0; z <= resolution; z++)
+        {
+            for (int x = 0; x <= resolution; x++)
+            {
+                int i = z * (resolution + 1) + x;
+                float wx = Coord.x * size + (float)x / resolution * size;
+                float wz = Coord.y * size + (float)z / resolution * size;
+                float h = generator.SampleHeight(wx, wz);
+                heights[x, z] = h;
+                verts[i] = new Vector3(wx, h, wz);
+                uvs[i] = new Vector2((float)x / resolution, (float)z / resolution);
+            }
+        }
+
+        int t = 0;
+        for (int z = 0; z < resolution; z++)
+        {
+            for (int x = 0; x < resolution; x++)
+            {
+                int i0 = z * (resolution + 1) + x;
+                int i1 = i0 + 1;
+                int i2 = i0 + (resolution + 1);
+                int i3 = i2 + 1;
+                tris[t++] = i0; tris[t++] = i2; tris[t++] = i1;
+                tris[t++] = i1; tris[t++] = i2; tris[t++] = i3;
+            }
+        }
+
+        Mesh mesh = new Mesh();
+        mesh.vertices = verts;
+        mesh.triangles = tris;
+        mesh.uv = uvs;
+        mesh.RecalculateNormals();
+        meshFilter.sharedMesh = mesh;
+        if (!meshCollider) meshCollider = gameObject.AddComponent<MeshCollider>();
+        meshCollider.sharedMesh = mesh;
+
+        // spawn environment
+        generator.SpawnEnvironment(this);
+        generator.SpawnMobs(this);
+        generator.ApplyWater(this);
+    }
+
+    public void ClearObjects()
+    {
+        foreach (var obj in spawnedObjects)
+        {
+            if (obj)
+                Destroy(obj);
+        }
+        spawnedObjects.Clear();
+    }
+
+    public void RegisterObject(GameObject obj)
+    {
+        spawnedObjects.Add(obj);
+    }
+}

--- a/Assets/Scripts/World/Utils/NoiseUtils.cs
+++ b/Assets/Scripts/World/Utils/NoiseUtils.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+public static class NoiseUtils
+{
+    /// <summary>
+    /// Gets 2D Perlin noise value for the given world coordinates and scale.
+    /// </summary>
+    public static float Perlin(float x, float z, float scale, int seed = 0)
+    {
+        x *= scale;
+        z *= scale;
+        float noise = Mathf.PerlinNoise(x + seed, z + seed);
+        return noise;
+    }
+}

--- a/Assets/Scripts/World/Utils/SimplePool.cs
+++ b/Assets/Scripts/World/Utils/SimplePool.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Simple generic object pool for GameObjects.
+/// </summary>
+public class SimplePool
+{
+    readonly GameObject prefab;
+    readonly Transform parent;
+    readonly Queue<GameObject> pool = new Queue<GameObject>();
+
+    public SimplePool(GameObject prefab, Transform parent = null)
+    {
+        this.prefab = prefab;
+        this.parent = parent;
+    }
+
+    public GameObject Get()
+    {
+        if (pool.Count > 0)
+        {
+            GameObject go = pool.Dequeue();
+            go.SetActive(true);
+            return go;
+        }
+        return Object.Instantiate(prefab, parent);
+    }
+
+    public void Return(GameObject go)
+    {
+        go.SetActive(false);
+        pool.Enqueue(go);
+    }
+}

--- a/Assets/Scripts/World/WorldGenerator.cs
+++ b/Assets/Scripts/World/WorldGenerator.cs
@@ -1,0 +1,204 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Manages loading/unloading of terrain chunks and provides utility
+/// methods for sampling terrain height and spawning objects.
+/// </summary>
+public class WorldGenerator : MonoBehaviour
+{
+    [Header("References")]
+    public Transform player;
+    public Material terrainMaterial;
+
+    [Header("World Settings")]
+    public float chunkSize = 20f;
+    public int chunkResolution = 64;
+    public int viewDistanceInChunks = 3;
+    public float biomeScale = 0.001f;
+    public float waterLevel = 0f;
+
+    [Header("Biomes")]
+    public BiomeDefinition[] biomes;
+
+    readonly Dictionary<Vector2Int, TerrainChunk> loadedChunks = new Dictionary<Vector2Int, TerrainChunk>();
+    readonly Queue<TerrainChunk> chunkPool = new Queue<TerrainChunk>();
+
+    Vector2Int lastPlayerChunk;
+
+    void Start()
+    {
+        UpdateVisibleChunks(true);
+    }
+
+    void Update()
+    {
+        Vector2Int current = GetChunkCoordFromPosition(player.position);
+        if (current != lastPlayerChunk)
+        {
+            UpdateVisibleChunks();
+            lastPlayerChunk = current;
+        }
+    }
+
+    Vector2Int GetChunkCoordFromPosition(Vector3 pos)
+    {
+        return new Vector2Int(Mathf.FloorToInt(pos.x / chunkSize), Mathf.FloorToInt(pos.z / chunkSize));
+    }
+
+    void UpdateVisibleChunks(bool force = false)
+    {
+        Vector2Int playerChunk = GetChunkCoordFromPosition(player.position);
+        HashSet<Vector2Int> needed = new HashSet<Vector2Int>();
+        for (int y = -viewDistanceInChunks; y <= viewDistanceInChunks; y++)
+        {
+            for (int x = -viewDistanceInChunks; x <= viewDistanceInChunks; x++)
+            {
+                Vector2Int coord = playerChunk + new Vector2Int(x, y);
+                needed.Add(coord);
+                if (!loadedChunks.ContainsKey(coord))
+                    LoadChunk(coord);
+            }
+        }
+
+        var keys = new List<Vector2Int>(loadedChunks.Keys);
+        foreach (var coord in keys)
+        {
+            if (!needed.Contains(coord))
+                UnloadChunk(coord);
+        }
+    }
+
+    void LoadChunk(Vector2Int coord)
+    {
+        TerrainChunk chunk;
+        if (chunkPool.Count > 0)
+        {
+            chunk = chunkPool.Dequeue();
+            chunk.gameObject.SetActive(true);
+        }
+        else
+        {
+            GameObject go = new GameObject();
+            go.AddComponent<MeshRenderer>();
+            chunk = go.AddComponent<TerrainChunk>();
+        }
+        loadedChunks.Add(coord, chunk);
+        chunk.transform.parent = transform;
+        chunk.GetComponent<MeshRenderer>().sharedMaterial = terrainMaterial;
+        chunk.Init(this, coord);
+    }
+
+    void UnloadChunk(Vector2Int coord)
+    {
+        if (loadedChunks.TryGetValue(coord, out TerrainChunk chunk))
+        {
+            chunk.ClearObjects();
+            chunk.gameObject.SetActive(false);
+            chunkPool.Enqueue(chunk);
+            loadedChunks.Remove(coord);
+        }
+    }
+
+    /// <summary>
+    /// Sample blended biome height at world coordinates.
+    /// </summary>
+    public float SampleHeight(float x, float z)
+    {
+        float biomeValue = NoiseUtils.Perlin(x, z, biomeScale);
+        float height = 0f;
+        float total = 0f;
+        foreach (var biome in biomes)
+        {
+            float weight = Mathf.InverseLerp(biome.minThreshold, biome.maxThreshold, biomeValue);
+            weight = Mathf.Clamp01(weight);
+            // smooth weight
+            weight = weight * weight * (3f - 2f * weight);
+            float roughnessNoise = NoiseUtils.Perlin(x, z, biome.roughness);
+            float h = biome.heightCurve.Evaluate(roughnessNoise) * biome.heightMultiplier;
+            height += h * weight;
+            total += weight;
+        }
+        if (total > 0f)
+            height /= total;
+        return height;
+    }
+
+    /// <summary>
+    /// Spawn environmental objects like trees based on chunk's dominant biome.
+    /// </summary>
+    public void SpawnEnvironment(TerrainChunk chunk)
+    {
+        BiomeDefinition biome = GetDominantBiome(chunk.Coord);
+        if (biome == null || biome.treePrefabs == null)
+            return;
+
+        foreach (var prefab in biome.treePrefabs)
+        {
+            Vector3 pos = new Vector3(
+                chunk.Coord.x * chunkSize + Random.Range(0f, chunkSize),
+                0f,
+                chunk.Coord.y * chunkSize + Random.Range(0f, chunkSize));
+            pos.y = SampleHeight(pos.x, pos.z);
+            GameObject go = Instantiate(prefab, pos, Quaternion.identity, chunk.transform);
+            chunk.RegisterObject(go);
+        }
+    }
+
+    /// <summary>
+    /// Spawn mobs for the chunk's dominant biome.
+    /// </summary>
+    public void SpawnMobs(TerrainChunk chunk)
+    {
+        BiomeDefinition biome = GetDominantBiome(chunk.Coord);
+        if (biome == null || biome.mobPrefabs == null)
+            return;
+
+        foreach (var prefab in biome.mobPrefabs)
+        {
+            Vector3 pos = new Vector3(
+                chunk.Coord.x * chunkSize + Random.Range(0f, chunkSize),
+                0f,
+                chunk.Coord.y * chunkSize + Random.Range(0f, chunkSize));
+            pos.y = SampleHeight(pos.x, pos.z);
+            GameObject go = Instantiate(prefab, pos, Quaternion.identity, chunk.transform);
+            chunk.RegisterObject(go);
+        }
+    }
+
+    BiomeDefinition GetDominantBiome(Vector2Int coord)
+    {
+        float centerX = coord.x * chunkSize + chunkSize * 0.5f;
+        float centerZ = coord.y * chunkSize + chunkSize * 0.5f;
+        float biomeValue = NoiseUtils.Perlin(centerX, centerZ, biomeScale);
+        BiomeDefinition best = null;
+        float bestW = 0f;
+        foreach (var biome in biomes)
+        {
+            float w = Mathf.InverseLerp(biome.minThreshold, biome.maxThreshold, biomeValue);
+            w = Mathf.Clamp01(w);
+            if (w > bestW)
+            {
+                bestW = w;
+                best = biome;
+            }
+        }
+        return best;
+    }
+
+    /// <summary>
+    /// Add a water plane for the chunk.
+    /// </summary>
+    public void ApplyWater(TerrainChunk chunk)
+    {
+        GameObject water = GameObject.CreatePrimitive(PrimitiveType.Plane);
+        water.transform.parent = chunk.transform;
+        water.transform.localScale = Vector3.one * (chunkSize / 10f);
+        Vector3 pos = new Vector3(
+            chunk.Coord.x * chunkSize + chunkSize * 0.5f,
+            waterLevel,
+            chunk.Coord.y * chunkSize + chunkSize * 0.5f);
+        water.transform.position = pos;
+        chunk.RegisterObject(water);
+    }
+}


### PR DESCRIPTION
## Summary
- add BiomeDefinition ScriptableObject for biome configuration
- create TerrainChunk to generate a mesh chunk with noise
- implement a WorldGenerator that spawns and recycles chunks around the player
- include basic noise utilities and a simple object pool

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68874e0f06dc8321b1c8366657d8cd56